### PR TITLE
WRI-1226:: external publications not showing for hyphenated names

### DIFF
--- a/wri_external_pub_list/wri_external_pub_list.module
+++ b/wri_external_pub_list/wri_external_pub_list.module
@@ -48,7 +48,7 @@ function grabTitles() {
         $first_name = $author['given'];
         $last_name = $author['family'];
         $authors[] = $last_name . ' ' . $first_name;
-        $feedName = strtr($first_name . ' ' . $last_name, ["á" => "a", "é" => "e", "í" => "i", "ó" => "o", "ú" => "u"]);
+        $feedName = strtr($first_name . ' ' . $last_name, ["á" => "a", "é" => "e", "í" => "i", "ó" => "o", "ú" => "u", "-" => " "]);
         $drupalName = strtr($authFirst . ' ' . $authLast, ["á" => "a", "é" => "e", "í" => "i", "ó" => "o", "ú" => "u"]);
         if ($feedName ===  $drupalName) {
           $publicationIsFromAuthor = TRUE;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [ ] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [ ] Check the commit's or even all commits' message styles matches our requested structure.
- [ ] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Currently on profile pages do not show the `external publications` tab if the person has a hyphen in their name.

Issue Number: WRI-1226


## What is the new behavior?
Profile pages of people with hyphens in theirs correctly show the `external publications` tab.

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
